### PR TITLE
新規ユーザ登録処理を一部修正

### DIFF
--- a/app/src/main/java/com/example/triplan/api/repository/TestRepository.kt
+++ b/app/src/main/java/com/example/triplan/api/repository/TestRepository.kt
@@ -8,7 +8,6 @@ import com.example.triplan.api.service.TestService
 import com.example.triplan.lib.JsonMapper
 import com.example.triplan.lib.responseType
 import com.example.triplan.model.Test
-import com.example.triplan.model.User
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/app/src/main/java/com/example/triplan/api/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/triplan/api/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.example.triplan.api.repository
 
-import android.util.Log
+import android.util. Log
 import com.example.triplan.api.ApiClient
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignInBody
@@ -10,7 +10,6 @@ import com.example.triplan.api.service.UserService
 import com.example.triplan.lib.JsonMapper
 import com.example.triplan.lib.responseType
 import com.example.triplan.model.User
-import com.google.android.gms.common.api.Api
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -39,7 +38,7 @@ class UserRepository {
                         }
 
                         else -> {
-                            Log.d("Error Code", response.code().toString())
+                            Log.e("Error Code", response.code().toString())
                             failure.invoke(ApiResponse.Failure(response.responseType()))
                         }
                     }

--- a/app/src/main/java/com/example/triplan/data/UserStore.kt
+++ b/app/src/main/java/com/example/triplan/data/UserStore.kt
@@ -17,8 +17,9 @@ object UserStore {
         }
     }
 
-    fun getToken(context: Context) {
+    fun setToken(context: Context) {
         val sharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
-        token.postValue(sharedPreferences.getString(DataKey.TOKEN.key, "") ?: "")
+        val tokenData = sharedPreferences.getString(DataKey.TOKEN.key, "") ?: ""
+        token.postValue(tokenData)
     }
  }

--- a/app/src/main/java/com/example/triplan/ui/content_plan_detail/ContentPlanDetailActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/content_plan_detail/ContentPlanDetailActivity.kt
@@ -3,18 +3,11 @@ package com.example.triplan.ui.content_plan_detail
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.os.PersistableBundle
-import android.text.Html
-import android.text.method.LinkMovementMethod
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.example.triplan.R
 import kotlinx.android.synthetic.main.activity_content_plan_detail.*
 import java.lang.Exception
-import java.util.stream.Stream
 
 data class Review(
     val image: Int,

--- a/app/src/main/java/com/example/triplan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/main/MainActivity.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
-import com.example.triplan.api.ApiResponse
 import com.example.triplan.ui.community.CommunityFragment
 import com.example.triplan.ui.now.NowFragment
 import com.example.triplan.ui.setting.SettingFragment
@@ -19,16 +17,17 @@ import kotlinx.android.synthetic.main.activity_main.*
 class MainActivity : AppCompatActivity() {
 
     private lateinit var viewModel: MainViewModel
+    private var backToast: Toast? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
-        val response = viewModel.getTest()
-        if (response is ApiResponse.Failure) {
-            Toast.makeText(this, response.errorMessage(this), Toast.LENGTH_SHORT).show()
-        }
+        viewModel.getTest({
+        }, {
+            Toast.makeText(this, it.errorMessage(this), Toast.LENGTH_SHORT).show()
+        })
 
         supportFragmentManager.beginTransaction()
             .replace(mainHostFragmentLayout.id, TopFragment())
@@ -80,6 +79,17 @@ class MainActivity : AppCompatActivity() {
 //        val navController = findNavController(mainHostFragment.id)
 //        bottomNavigationView.setupWithNavController(navController)
 //        NavigationUI.setupWithNavController(bottomNavigationView, navController)
+    }
+
+    override fun onBackPressed() {
+        backToast?.let {
+            if (it.view.isShown) {
+                this.moveTaskToBack(true)
+            }
+        }
+
+        backToast = Toast.makeText(this, "もう一度押すと終了します", Toast.LENGTH_SHORT)
+        backToast?.show()
     }
 
     companion object {

--- a/app/src/main/java/com/example/triplan/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/triplan/ui/main/MainViewModel.kt
@@ -4,20 +4,22 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.repository.TestRepository
+import com.example.triplan.data.UserStore
 import com.example.triplan.model.Test
 
 class MainViewModel: ViewModel() {
     private val testRepository: TestRepository = TestRepository()
+    val userStore = UserStore
     val test = MutableLiveData<Test>()
 
-    fun getTest(): ApiResponse {
-        var response: ApiResponse = ApiResponse.Failure(ApiResponse.ResponseType.Failure)
+    fun getTest(
+        success: ((ApiResponse.Success<Test>) -> Unit),
+        failure: ((ApiResponse.Failure) -> Unit)
+    ) {
         testRepository.getTest({
-            test.postValue(it.data)
-            response = it
+            success.invoke(it)
         }, {
-            response = it
+            failure.invoke(it)
         })
-        return response
     }
 }

--- a/app/src/main/java/com/example/triplan/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/example/triplan/ui/setting/SettingFragment.kt
@@ -1,14 +1,10 @@
 package com.example.triplan.ui.setting
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.triplan.R
 import kotlinx.android.synthetic.main.fragment_setting.*
 

--- a/app/src/main/java/com/example/triplan/ui/setting/SettingRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/example/triplan/ui/setting/SettingRecyclerViewAdapter.kt
@@ -1,11 +1,7 @@
 package com.example.triplan.ui.setting
 
-import android.content.Context
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.example.triplan.R
 import com.example.triplan.lib.ViewHolder

--- a/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
@@ -3,19 +3,15 @@ package com.example.triplan.ui.sign_up
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
-import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignUpBody
 import com.example.triplan.data.UserStore
 import com.example.triplan.lib.RegexPattern
 import com.example.triplan.model.Gender
-import com.example.triplan.model.User
 import com.example.triplan.ui.main.MainActivity
 import kotlinx.android.synthetic.main.activity_sign_up.*
 
@@ -48,8 +44,8 @@ class SignUpActivity : AppCompatActivity() {
         nearestStationStationSpinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         signUpSpinnerNearestStationStation.adapter = nearestStationStationSpinnerAdapter
 
-        signUpButton.setOnClickListener {
-            it.isEnabled = false
+        signUpButton.setOnClickListener { view ->
+            view.isEnabled = false
             val name = signUpTextNameForm.text.toString().trim()
             val email = signUpTextEmailForm.text.toString().trim()
             val password = signUpTextPasswordForm.text.toString().trim()
@@ -62,39 +58,30 @@ class SignUpActivity : AppCompatActivity() {
 
             if (email.isEmpty() || Regex(RegexPattern.EMAIL).containsMatchIn(email).not()) {
                 Toast.makeText(this, "メールアドレスを正しく入力してください", Toast.LENGTH_SHORT).show()
-                it.isEnabled = true
+                view.isEnabled = true
                 return@setOnClickListener
             }
 
             if (password.isEmpty()) {
                 Toast.makeText(this, "パスワードを入力してください", Toast.LENGTH_SHORT).show()
-                it.isEnabled = true
+                view.isEnabled = true
                 return@setOnClickListener
             }
 
             if (age.isEmpty()) {
                 Toast.makeText(this, "年齢を入力してください", Toast.LENGTH_SHORT).show()
-                it.isEnabled = true
+                view.isEnabled = true
                 return@setOnClickListener
             }
 
             val signUpBody = SignUpBody(name, email, password, 0, age.toInt(), gender.value)
 
-            val response = viewModel.sendSignUpData(signUpBody)
-            when (response) {
-                is ApiResponse.Failure -> {
-                    Log.d("error", response.responseType.toString())
-                    Toast.makeText(this, response.errorMessage(this), Toast.LENGTH_SHORT).show()
-                    it.isEnabled = true
-                }
-
-                is ApiResponse.Success<*> -> {
-                    if (response.data is User) {
-//                        userStore.user.postValue(response.data)
-                        MainActivity.start(this)
-                    }
-                }
-            }
+            viewModel.sendSignUpData(signUpBody, {
+                MainActivity.start(this)
+            }, {response ->
+                Toast.makeText(this, response.errorMessage(this), Toast.LENGTH_SHORT).show()
+                view.isEnabled = true
+            })
         }
     }
 

--- a/app/src/main/java/com/example/triplan/ui/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/SignUpViewModel.kt
@@ -1,27 +1,30 @@
 package com.example.triplan.ui.sign_up
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignUpBody
 import com.example.triplan.api.repository.UserRepository
+import com.example.triplan.data.UserStore
 import com.example.triplan.model.Gender
 import com.example.triplan.model.User
 
 class SignUpViewModel : ViewModel() {
     private val userRepository = UserRepository()
-    val user = MutableLiveData<User>()
+    val userStore = UserStore
 
-    fun sendSignUpData(signUpBody: SignUpBody): ApiResponse {
-        var response: ApiResponse = ApiResponse.Failure(ApiResponse.ResponseType.Failure)
+    fun sendSignUpData(
+        signUpBody: SignUpBody,
+        success: ((ApiResponse.Success<User>) -> Unit),
+        failure: ((ApiResponse.Failure) -> Unit))  {
         userRepository.signUp(signUpBody, {
-            user.postValue(it.data)
-            response = it
+            userStore.user.postValue(it.data)
+            success.invoke(it)
         }, {
-            response = it
+            failure.invoke(it)
         })
-        return response
     }
 }


### PR DESCRIPTION
## 目的
新規登録の際のアクティビティのエラーハンドリング方法を修正

## 方針
エラーハンドリングをApiResponseを使ってやろうとしたが、非同期処理に変更
不要なライブラリを消す

## 実装
方針通り

## テスト
SignUpActivityからMainActivityに遷移できればOK
