### PR TITLE
ユーザトークンを端末に保存、駅情報と線路情報を取得して新規登録画面に反映

### DIFF
--- a/app/src/main/java/com/example/triplan/api/model/Body/SignUpBody.kt
+++ b/app/src/main/java/com/example/triplan/api/model/Body/SignUpBody.kt
@@ -10,11 +10,7 @@ data class SignUpBody(
     val email: String,
     @Json(name = "password")
     val password: String,
-//    @Json(name = "line_id")
-//    val lineId: Int,
-//    @Json(name = "station_id")
-//    val stationId: Int,
-    @Json(name = "lineStationId")
+    @Json(name = "line_station_id")
     val stationLineId: Int,
     @Json(name = "age")
     val age: Int,

--- a/app/src/main/java/com/example/triplan/api/model/Json/LineJson.kt
+++ b/app/src/main/java/com/example/triplan/api/model/Json/LineJson.kt
@@ -1,6 +1,10 @@
 package com.example.triplan.api.model.Json
 
+import com.squareup.moshi.Json
+
 data class LineJson(
+    @Json(name = "id")
     val id: Int,
+    @Json(name = "name")
     val name: String
 )

--- a/app/src/main/java/com/example/triplan/api/model/Json/LinesJson.kt
+++ b/app/src/main/java/com/example/triplan/api/model/Json/LinesJson.kt
@@ -1,0 +1,8 @@
+package com.example.triplan.api.model.Json
+
+import com.squareup.moshi.Json
+
+data class LinesJson(
+    @Json(name = "lines")
+    val lines: List<LineJson>
+)

--- a/app/src/main/java/com/example/triplan/api/model/Json/StationJson.kt
+++ b/app/src/main/java/com/example/triplan/api/model/Json/StationJson.kt
@@ -1,6 +1,10 @@
 package com.example.triplan.api.model.Json
 
+import com.squareup.moshi.Json
+
 data class StationJson(
+    @Json(name = "id")
     val id: Int,
+    @Json(name = "name")
     val name: String
 )

--- a/app/src/main/java/com/example/triplan/api/model/Json/StationsJson.kt
+++ b/app/src/main/java/com/example/triplan/api/model/Json/StationsJson.kt
@@ -1,0 +1,8 @@
+package com.example.triplan.api.model.Json
+
+import com.squareup.moshi.Json
+
+data class StationsJson (
+    @Json(name = "stations")
+    val stations: List<StationJson>
+)

--- a/app/src/main/java/com/example/triplan/api/repository/CommonRepository.kt
+++ b/app/src/main/java/com/example/triplan/api/repository/CommonRepository.kt
@@ -3,33 +3,34 @@ package com.example.triplan.api.repository
 import android.util.Log
 import com.example.triplan.api.ApiClient
 import com.example.triplan.api.ApiResponse
-import com.example.triplan.api.model.Body.SignInBody
-import com.example.triplan.api.model.Body.SignUpBody
-import com.example.triplan.api.model.Json.UserJson
-import com.example.triplan.api.service.UserService
+import com.example.triplan.api.model.Json.LinesJson
+import com.example.triplan.api.model.Json.StationJson
+import com.example.triplan.api.model.Json.StationsJson
+import com.example.triplan.api.service.CommonService
 import com.example.triplan.lib.JsonMapper
 import com.example.triplan.lib.responseType
-import com.example.triplan.model.User
+import com.example.triplan.model.Line
+import com.example.triplan.model.Lines
+import com.example.triplan.model.Stations
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-class UserRepository {
-    fun signUp(
-        signUpBody: SignUpBody,
-        success: ((ApiResponse.Success<User>) -> Unit),
+class CommonRepository {
+    fun getLines(
+        success: ((ApiResponse.Success<Lines>) -> Unit),
         failure: ((ApiResponse.Failure) -> Unit)
     ) {
-        ApiClient<UserService>()
-            .getService(UserService::class.java)
-            .signUp(signUpBody)
-            .enqueue(object : Callback<UserJson>{
-                override fun onFailure(call: Call<UserJson>, t: Throwable) {
+        ApiClient<CommonService>()
+            .getService(CommonService::class.java)
+            .getLInes()
+            .enqueue(object : Callback<LinesJson>{
+                override fun onFailure(call: Call<LinesJson>, t: Throwable) {
                     Log.e("Network Failure", t.message.toString())
                     failure.invoke(ApiResponse.Failure(ApiResponse.ResponseType.Failure))
                 }
 
-                override fun onResponse(call: Call<UserJson>, response: Response<UserJson>) {
+                override fun onResponse(call: Call<LinesJson>, response: Response<LinesJson>) {
                     when (response.responseType) {
                         ApiResponse.ResponseType.Success -> {
                             response.body()?.let {
@@ -46,20 +47,22 @@ class UserRepository {
             })
     }
 
-    fun singIn(
-        signInBody: SignInBody,
-        success: ((ApiResponse.Success<User>) -> Unit),
+    fun getStations(
+        line: Line,
+        success: ((ApiResponse.Success<Stations>) -> Unit),
         failure: ((ApiResponse.Failure) -> Unit)
     ) {
-        ApiClient<UserService>()
-            .getService(UserService::class.java)
-            .signIn(signInBody)
-            .enqueue(object : Callback<UserJson>{
-                override fun onFailure(call: Call<UserJson>, t: Throwable) {
+        ApiClient<CommonService>()
+            .getService(CommonService::class.java)
+            .getStations(line.id)
+            .enqueue(object : Callback<StationsJson> {
+                override fun onFailure(call: Call<StationsJson>, t: Throwable) {
+                    Log.e("Network Failure", t.message.toString())
                     failure.invoke(ApiResponse.Failure(ApiResponse.ResponseType.Failure))
                 }
 
-                override fun onResponse(call: Call<UserJson>, response: Response<UserJson>) {
+                override fun onResponse(call: Call<StationsJson>, response: Response<StationsJson>
+                ) {
                     when (response.responseType) {
                         ApiResponse.ResponseType.Success -> {
                             response.body()?.let {
@@ -73,7 +76,8 @@ class UserRepository {
                         }
                     }
                 }
-            })
-
+        })
     }
+
+
 }

--- a/app/src/main/java/com/example/triplan/api/repository/TestRepository.kt
+++ b/app/src/main/java/com/example/triplan/api/repository/TestRepository.kt
@@ -28,7 +28,7 @@ class TestRepository {
                 }
 
                 override fun onResponse(call: Call<TestJson>, response: Response<TestJson>) {
-                    when (response.responseType()) {
+                    when (response.responseType) {
                         ApiResponse.ResponseType.Success -> {
                             response.body()?.let {
                                 success.invoke(ApiResponse.Success(JsonMapper.toMapping(it), ApiResponse.ResponseType.Success))
@@ -36,7 +36,7 @@ class TestRepository {
                         }
 
                         else -> {
-                            failure.invoke(ApiResponse.Failure(response.responseType()))
+                            failure.invoke(ApiResponse.Failure(response.responseType))
                         }
                     }
                 }

--- a/app/src/main/java/com/example/triplan/api/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/triplan/api/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.example.triplan.api.repository
 
-import android.util. Log
+import android.util.Log
 import com.example.triplan.api.ApiClient
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignInBody
@@ -56,7 +56,7 @@ class UserRepository {
             .signIn(signInBody)
             .enqueue(object : Callback<UserJson>{
                 override fun onFailure(call: Call<UserJson>, t: Throwable) {
-
+                    failure.invoke(ApiResponse.Failure(ApiResponse.ResponseType.Failure))
                 }
 
                 override fun onResponse(call: Call<UserJson>, response: Response<UserJson>) {

--- a/app/src/main/java/com/example/triplan/api/service/CommonService.kt
+++ b/app/src/main/java/com/example/triplan/api/service/CommonService.kt
@@ -1,0 +1,15 @@
+package com.example.triplan.api.service
+
+import com.example.triplan.api.model.Json.LinesJson
+import com.example.triplan.api.model.Json.StationsJson
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface CommonService {
+    @GET("/api/v1/lines")
+    fun getLInes(): Call<LinesJson>
+
+    @GET("/api/v1/line/{lineId}/stations")
+    fun getStations(@Path("lineId") lineId: Int): Call<StationsJson>
+}

--- a/app/src/main/java/com/example/triplan/data/UserStore.kt
+++ b/app/src/main/java/com/example/triplan/data/UserStore.kt
@@ -1,6 +1,7 @@
 package com.example.triplan.data
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import com.example.triplan.R
 import com.example.triplan.model.User
@@ -10,16 +11,16 @@ object UserStore {
     val token = MutableLiveData<String>()
     fun saveToken(context: Context) {
         val sharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
-        user.value?.let {
+        token.value?.let {
             sharedPreferences.edit()
-                .putString(DataKey.TOKEN.key, it.token)
+                .putString(DataKey.TOKEN.key, it)
                 .apply()
         }
     }
 
     fun setToken(context: Context) {
         val sharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
-        val tokenData = sharedPreferences.getString(DataKey.TOKEN.key, "") ?: ""
-        token.postValue(tokenData)
+        val tokenData = sharedPreferences.getString(DataKey.TOKEN.key, "token") ?: "token"
+        token.value = tokenData
     }
  }

--- a/app/src/main/java/com/example/triplan/data/UserStore.kt
+++ b/app/src/main/java/com/example/triplan/data/UserStore.kt
@@ -20,7 +20,7 @@ object UserStore {
 
     fun setToken(context: Context) {
         val sharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
-        val tokenData = sharedPreferences.getString(DataKey.TOKEN.key, "token") ?: "token"
+        val tokenData = sharedPreferences.getString(DataKey.TOKEN.key, "") ?: ""
         token.value = tokenData
     }
  }

--- a/app/src/main/java/com/example/triplan/lib/Extension.kt
+++ b/app/src/main/java/com/example/triplan/lib/Extension.kt
@@ -3,11 +3,18 @@ package com.example.triplan.lib
 import com.example.triplan.api.ApiResponse
 import retrofit2.Response
 
-fun <T> Response<T>.responseType() = when (this.code()) {
-    in 200..299 -> ApiResponse.ResponseType.Success
-    in 400..499 -> ApiResponse.ResponseType.ClientError
-    in 500..599 -> ApiResponse.ResponseType.ServerError
-    else -> ApiResponse.ResponseType.Failure
-}
+val Response<*>.responseType: ApiResponse.ResponseType
+    get() = when (this.code()) {
+        in 200..299 -> ApiResponse.ResponseType.Success
+        in 400..499 -> ApiResponse.ResponseType.ClientError
+        in 500..599 -> ApiResponse.ResponseType.ServerError
+        else -> ApiResponse.ResponseType.Failure
+    }
 
 fun String.isMatch(pattern: String) = Regex(pattern).containsMatchIn(this)
+
+fun<T> List<T>.getSafety(index: Int): T? {
+    if (index >= this.size) return null
+
+    return this[index]
+}

--- a/app/src/main/java/com/example/triplan/lib/JsonMapper.kt
+++ b/app/src/main/java/com/example/triplan/lib/JsonMapper.kt
@@ -1,9 +1,6 @@
 package com.example.triplan.lib
 
-import com.example.triplan.api.model.Json.LineJson
-import com.example.triplan.api.model.Json.StationJson
-import com.example.triplan.api.model.Json.TestJson
-import com.example.triplan.api.model.Json.UserJson
+import com.example.triplan.api.model.Json.*
 import com.example.triplan.model.*
 
 class JsonMapper {
@@ -28,9 +25,17 @@ class JsonMapper {
             name = json.name
         )
 
+        fun toMapping(json: LinesJson) = Lines(
+            json.lines.map { Line(it.id, it.name) }.toList()
+        )
+
         fun toMapping(json: StationJson) = Station(
             id =  json.id,
             name = json.name
+        )
+
+        fun toMapping(json: StationsJson) = Stations (
+            json.stations.map { Station(it.id, it.name) }.toList()
         )
     }
 }

--- a/app/src/main/java/com/example/triplan/model/LInes.kt
+++ b/app/src/main/java/com/example/triplan/model/LInes.kt
@@ -1,0 +1,5 @@
+package com.example.triplan.model
+
+data class Lines(
+    val lines: List<Line>
+)

--- a/app/src/main/java/com/example/triplan/model/Stations.kt
+++ b/app/src/main/java/com/example/triplan/model/Stations.kt
@@ -1,0 +1,5 @@
+package com.example.triplan.model
+
+data class Stations(
+    val stations: List<Station>
+)

--- a/app/src/main/java/com/example/triplan/ui/init/InitActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/init/InitActivity.kt
@@ -2,14 +2,26 @@ package com.example.triplan.ui.init
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
+import com.example.triplan.data.UserStore
+import com.example.triplan.ui.main.MainActivity
 import com.example.triplan.ui.welcome.WelcomeActivity
 
 class InitActivity : AppCompatActivity() {
+    lateinit var viewModel: InitViewModel
+    private val userStore = UserStore
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_init)
 
-        WelcomeActivity.start(this)
+        viewModel = ViewModelProviders.of(this).get(InitViewModel::class.java)
+        viewModel.userStore.setToken(applicationContext)
+        val token = viewModel.userStore.token.value
+        if (token.isNullOrEmpty()) {
+            WelcomeActivity.start(this)
+        } else {
+            MainActivity.start(this)
+        }
     }
 }

--- a/app/src/main/java/com/example/triplan/ui/init/InitViewModel.kt
+++ b/app/src/main/java/com/example/triplan/ui/init/InitViewModel.kt
@@ -1,0 +1,8 @@
+package com.example.triplan.ui.init
+
+import androidx.lifecycle.ViewModel
+import com.example.triplan.data.UserStore
+
+class InitViewModel : ViewModel() {
+    val userStore = UserStore
+}

--- a/app/src/main/java/com/example/triplan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/main/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
+import com.example.triplan.data.UserStore
 import com.example.triplan.ui.community.CommunityFragment
 import com.example.triplan.ui.now.NowFragment
 import com.example.triplan.ui.setting.SettingFragment
@@ -17,6 +18,7 @@ import kotlinx.android.synthetic.main.activity_main.*
 class MainActivity : AppCompatActivity() {
 
     private lateinit var viewModel: MainViewModel
+    private val userStore = UserStore
     private var backToast: Toast? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/triplan/ui/setting/SettingRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/example/triplan/ui/setting/SettingRecyclerViewAdapter.kt
@@ -5,13 +5,13 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.triplan.R
 import com.example.triplan.lib.ViewHolder
+import com.example.triplan.lib.getSafety
 import kotlinx.android.synthetic.main.item_setting.view.*
 
 
 class SettingRecyclerViewAdapter(
     private val settingLists: List<String>
 ): RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-
     override fun getItemCount(): Int {
         return settingLists.size
     }
@@ -22,6 +22,6 @@ class SettingRecyclerViewAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        holder.itemView.settingText.text = settingLists[position]
+        holder.itemView.settingText.text = settingLists.getSafety(position)
     }
 }

--- a/app/src/main/java/com/example/triplan/ui/sign_in/SignInActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_in/SignInActivity.kt
@@ -3,12 +3,13 @@ package com.example.triplan.ui.sign_in
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
 import com.example.triplan.api.model.Body.SignInBody
+import com.example.triplan.data.UserStore
 import com.example.triplan.lib.RegexPattern
 import com.example.triplan.lib.isMatch
 import com.example.triplan.ui.main.MainActivity
@@ -16,12 +17,22 @@ import kotlinx.android.synthetic.main.activity_sign_in.*
 
 class SignInActivity : AppCompatActivity() {
     private lateinit var viewModel: SignInViewModel
+    private val userStore = UserStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sign_in)
 
         viewModel = ViewModelProviders.of(this).get(SignInViewModel::class.java)
+
+        userStore.user.observe(this, Observer {
+            userStore.token.postValue(it.token)
+        })
+
+        userStore.token.observe(this, Observer {
+            userStore.saveToken(applicationContext)
+        })
+
         signInButton.setOnClickListener { view ->
             view.isEnabled = false
             val email = signInTextEmailForm.text.toString().trim()
@@ -40,8 +51,8 @@ class SignInActivity : AppCompatActivity() {
             }
 
             val signInBody = SignInBody(email, password)
+
             viewModel.sendSignInData(signInBody, {
-                Log.d("aaa", "name: ${it.data.name} email: ${it.data.email}")
                 MainActivity.start(this)
             }, {
                 Toast.makeText(this, it.errorMessage(this), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/triplan/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_in/SignInViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.triplan.ui.sign_in
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignInBody

--- a/app/src/main/java/com/example/triplan/ui/sign_up/LineArrayAdapter.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/LineArrayAdapter.kt
@@ -1,0 +1,73 @@
+package com.example.triplan.ui.sign_up
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import com.example.triplan.R
+import com.example.triplan.lib.getSafety
+import com.example.triplan.model.Line
+
+class LineArrayAdapter (
+    context: Context,
+    private val viewResources: Int,
+    private var dropdownViewResources : Int,
+    private val lines: List<Line>
+): ArrayAdapter<Line>(context, viewResources, lines) {
+
+    init {
+        this.setDropDownViewResource(dropdownViewResources)
+    }
+
+    override fun getCount(): Int  = lines.size
+
+    override fun getItem(position: Int): Line? = lines.getSafety(position)
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val line = lines.getSafety(position)
+        val view = when (convertView) {
+            null -> {
+                val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+                layoutInflater.inflate(viewResources, null)
+            }
+
+            else -> convertView
+        }
+
+        val textView = view.findViewById<TextView>(android.R.id.text1)
+        textView.text =line?.name
+
+        return view
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val line = lines.getSafety(position)
+        val view = when (convertView) {
+            null -> {
+                val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+                layoutInflater.inflate(dropdownViewResources, null)
+            }
+
+            else -> convertView
+        }
+
+        when (dropdownViewResources) {
+            R.layout.item_spinner_dropdown -> {
+                val textView = view.findViewById<TextView>(R.id.spinnerItemTextView)
+                textView.text = line?.name
+            }
+
+            else -> { }
+        }
+
+        return view
+    }
+
+    override fun setDropDownViewResource(resource: Int) {
+        dropdownViewResources = resource
+        super.setDropDownViewResource(dropdownViewResources)
+    }
+
+}

--- a/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
@@ -3,6 +3,8 @@ package com.example.triplan.ui.sign_up
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -35,24 +37,62 @@ class SignUpActivity : AppCompatActivity() {
             userStore.saveToken(applicationContext)
         })
 
-        val nearestStationLineSpinnerAdapter = ArrayAdapter(
-            this,
-            android.R.layout.simple_spinner_item,
-            arrayOf("山手線", "京浜東北線", "中央線", "東海道線", "常磐線", "埼京線"))
+        viewModel.line.observe(this, Observer {
+            val position = signUpSpinnerNearestStationLine.selectedItemPosition
+            val adapter = signUpSpinnerNearestStationLine.adapter as LineArrayAdapter
+            viewModel.line.value?.let { line ->
+                // apiを叩いて、station adapterに値をセットする
+                viewModel.getStations(line, {
+                    val stations = it.data.stations
+                    val stationsArrayAdapter = StationArrayAdapter(
+                        this,
+                        android.R.layout.simple_spinner_item,
+                        R.layout.item_spinner_dropdown,
+                        stations)
+                    signUpSpinnerNearestStationStation.adapter = stationsArrayAdapter
+                }, {
+                    Toast.makeText(this, it.errorMessage(this), Toast.LENGTH_SHORT).show()
+                })
+            }
+        })
 
-        nearestStationLineSpinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        signUpSpinnerNearestStationLine.adapter =nearestStationLineSpinnerAdapter
+        viewModel.getLines({
+            val lines = it.data.lines
+            val nearestStationLineSpinnerAdapter = LineArrayAdapter(
+                this,
+                android.R.layout.simple_spinner_item,
+                R.layout.item_spinner_dropdown,
+                lines
+            )
+            signUpSpinnerNearestStationLine.adapter =nearestStationLineSpinnerAdapter
+        }, {
+            Toast.makeText(this, it.errorMessage(this), Toast.LENGTH_SHORT).show()
+        })
 
         val genderList = resources.getStringArray(R.array.sign_up_text_gender_form_array_text)
         val signUpSpinnerGenderAdapter = ArrayAdapter<String>(this, android.R.layout.simple_spinner_dropdown_item, genderList)
         signUpSpinnerGender.adapter = signUpSpinnerGenderAdapter
 
-        val nearestStationStationSpinnerAdapter = ArrayAdapter(
-            this,
-            android.R.layout.simple_spinner_item,
-            (1..10).map { "${it}駅" }.toTypedArray())
-        nearestStationStationSpinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        signUpSpinnerNearestStationStation.adapter = nearestStationStationSpinnerAdapter
+        signUpSpinnerNearestStationLine.onItemSelectedListener = object : AdapterView.OnItemSelectedListener{
+            override fun onNothingSelected(parent: AdapterView<*>?) {
+
+            }
+
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                when (signUpSpinnerNearestStationLine.adapter) {
+                    is LineArrayAdapter -> {
+                        val adapter = signUpSpinnerNearestStationLine.adapter as LineArrayAdapter
+                        val line = adapter.getItem(position)
+                        line?.let {
+                            viewModel.line.value = it
+                        }
+                    }
+                    else -> {
+
+                    }
+                }
+            }
+        }
 
         signUpButton.setOnClickListener { view ->
             view.isEnabled = false

--- a/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/SignUpActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.triplan.R
 import com.example.triplan.api.model.Body.SignUpBody
@@ -25,6 +26,14 @@ class SignUpActivity : AppCompatActivity() {
         setContentView(R.layout.activity_sign_up)
 
         viewModel = ViewModelProviders.of(this).get(SignUpViewModel::class.java)
+
+        userStore.user.observe(this, Observer {
+            userStore.token.postValue(it.token)
+        })
+
+        userStore.token.observe(this, Observer {
+            userStore.saveToken(applicationContext)
+        })
 
         val nearestStationLineSpinnerAdapter = ArrayAdapter(
             this,

--- a/app/src/main/java/com/example/triplan/ui/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/SignUpViewModel.kt
@@ -7,14 +7,17 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.triplan.api.ApiResponse
 import com.example.triplan.api.model.Body.SignUpBody
+import com.example.triplan.api.repository.CommonRepository
 import com.example.triplan.api.repository.UserRepository
 import com.example.triplan.data.UserStore
-import com.example.triplan.model.Gender
-import com.example.triplan.model.User
+import com.example.triplan.model.*
 
 class SignUpViewModel : ViewModel() {
     private val userRepository = UserRepository()
+    private val commonRepository = CommonRepository()
     val userStore = UserStore
+    val line = MutableLiveData<Line>()
+    val station = MutableLiveData<Stations>()
 
     fun sendSignUpData(
         signUpBody: SignUpBody,
@@ -22,6 +25,29 @@ class SignUpViewModel : ViewModel() {
         failure: ((ApiResponse.Failure) -> Unit))  {
         userRepository.signUp(signUpBody, {
             userStore.user.postValue(it.data)
+            success.invoke(it)
+        }, {
+            failure.invoke(it)
+        })
+    }
+
+    fun getLines(
+        success: ((ApiResponse.Success<Lines>) -> Unit),
+        failure: ((ApiResponse.Failure) -> Unit)
+    ) {
+        commonRepository.getLines({
+            success.invoke(it)
+        }, {
+            failure.invoke(it)
+        })
+    }
+
+    fun getStations(
+        line: Line,
+        success: ((ApiResponse.Success<Stations>) -> Unit),
+        failure: ((ApiResponse.Failure) -> Unit)
+    ) {
+        commonRepository.getStations(line, {
             success.invoke(it)
         }, {
             failure.invoke(it)

--- a/app/src/main/java/com/example/triplan/ui/sign_up/StationArrayAdapter.kt
+++ b/app/src/main/java/com/example/triplan/ui/sign_up/StationArrayAdapter.kt
@@ -1,0 +1,65 @@
+package com.example.triplan.ui.sign_up
+
+import android.content.Context
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import com.example.triplan.R
+import com.example.triplan.lib.getSafety
+import com.example.triplan.model.Station
+
+class StationArrayAdapter (
+    context: Context,
+    private val viewResources: Int,
+    private val dropdownViewResources: Int,
+    private val stations: List<Station>
+): ArrayAdapter<Station>(context, viewResources, stations) {
+    override fun getCount(): Int  = stations.size
+
+    override fun getItem(position: Int): Station? = stations.getSafety(position)
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        Log.d("aaa", stations.toString())
+        val station = stations.getSafety(position)
+        val view = when(convertView) {
+            null -> {
+                val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+                layoutInflater.inflate(viewResources, null)
+            }
+
+            else -> convertView
+        }
+
+        val textView = view.findViewById<TextView>(android.R.id.text1)
+        textView.text =station?.name
+
+        return view
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val stations = stations.getSafety(position)
+
+        val view = when (convertView) {
+            null -> {
+                val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+                layoutInflater.inflate(dropdownViewResources, null)
+            }
+
+            else -> convertView
+        }
+
+        when (dropdownViewResources) {
+            R.layout.item_spinner_dropdown -> {
+                val textView = view.findViewById<TextView>(R.id.spinnerItemTextView)
+                textView.text = stations?.name
+            }
+
+            else -> { }
+        }
+
+        return view
+    }
+}

--- a/app/src/main/java/com/example/triplan/ui/welcome/WelcomeActivity.kt
+++ b/app/src/main/java/com/example/triplan/ui/welcome/WelcomeActivity.kt
@@ -5,17 +5,17 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.example.triplan.R
-import com.example.triplan.data.UserStore
 import com.example.triplan.ui.sign_in.SignInActivity
 import com.example.triplan.ui.sign_up.SignUpActivity
 import kotlinx.android.synthetic.main.activity_welcome.*
 
 class WelcomeActivity : AppCompatActivity() {
-    val userStore = UserStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_welcome)
+
+
         createAccountButton.setOnClickListener {
             SignUpActivity.start(this)
         }

--- a/app/src/main/res/layout/activity_init.xml
+++ b/app/src/main/res/layout/activity_init.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.init.InitActivity">
+    <TextView
+        android:id="@+id/topTitleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name_upper"
+        android:textSize="@dimen/top_title_text_text_size"
+        android:textColor="@color/triplan_black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -165,6 +165,7 @@
         android:layout_marginTop="@dimen/sign_up_spinner_nearest_station_line_margin_top"
         android:layout_marginStart="@dimen/sign_up_text_form_margin_start"
         android:layout_marginEnd="@dimen/sign_up_text_form_margin_end"
+        android:spinnerMode="dialog"
         app:layout_constraintStart_toEndOf="@id/signUpTextNearestStationLine"
         app:layout_constraintTop_toBottomOf="@id/signUpTextNearestStation" />
 
@@ -187,6 +188,7 @@
         android:layout_marginTop="@dimen/sign_up_spinner_nearest_station_line_margin_top"
         android:layout_marginStart="@dimen/sign_up_text_form_margin_start"
         android:layout_marginEnd="@dimen/sign_up_text_form_margin_end"
+        android:spinnerMode="dialog"
         app:layout_constraintStart_toEndOf="@id/signUpTextNearestStation"
         app:layout_constraintTop_toBottomOf="@id/signUpSpinnerNearestStationLine" />
 

--- a/app/src/main/res/layout/item_spinner_dropdown.xml
+++ b/app/src/main/res/layout/item_spinner_dropdown.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/spinnerItemTextView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:ellipsize="marquee"
+    android:textSize="@dimen/spinner_item_text_view_text_size"
+    android:textColor="@color/triplan_blue"
+    android:gravity="center|start"
+    android:elevation="@dimen/spinner_item_text_view_elevation"
+    android:paddingStart="@dimen/spinner_item_text_view_padding_start"
+    android:paddingTop="@dimen/spinner_item_text_view_padding_top"
+    android:paddingBottom="@dimen/spinner_item_text_view_padding_bottom"
+/>
+

--- a/app/src/main/res/layout/item_spinner_dropdown.xml
+++ b/app/src/main/res/layout/item_spinner_dropdown.xml
@@ -5,7 +5,7 @@
     android:layout_height="wrap_content"
     android:ellipsize="marquee"
     android:textSize="@dimen/spinner_item_text_view_text_size"
-    android:textColor="@color/triplan_blue"
+    android:textColor="@color/triplan_black"
     android:gravity="center|start"
     android:elevation="@dimen/spinner_item_text_view_elevation"
     android:paddingStart="@dimen/spinner_item_text_view_padding_start"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -236,4 +236,12 @@
     <dimen name="content_plan_traffic_item_detail_text_size">16sp</dimen>
     <dimen name="content_plan_traffic_item_detail_margin_start">36dp</dimen>
     <dimen name="content_plan_traffic_item_detail_margin_top">12dp</dimen>
+
+    <!-- dropdown item of spinner  -->
+    <dimen name="spinner_item_text_view_text_size">16sp</dimen>
+    <dimen name="spinner_item_text_view_elevation">5dp</dimen>
+    <dimen name="spinner_item_text_view_padding_start">10dp</dimen>
+    <dimen name="spinner_item_text_view_padding_top">15dp</dimen>
+    <dimen name="spinner_item_text_view_padding_bottom">15dp</dimen>
+
 </resources>


### PR DESCRIPTION
## 目的
ログイン、新規登録はすでにできるが端末にトークンを保存していないためアプリを毎回開く度にログインが必要になってしまう

トークンを端末に保存して、アプリを開く度に保存したトークンを元にユーザ情報を取得したい

加えて、新規登録の際に駅情報と線路情報がモックになっているので本番に対応する実装に修正する
## 方針
- viewmodelからuserStoreにアクセスして、userStoreから端末にトークンを保存する
- どこを非同期で処理して、どこを同期的に処理するかを確かめながら実装を行う
- 新規登録画面を開いた時に非同期で線路情報を取得するapiを叩いて、非同期的に取得した情報をviewに反映する
- 新規登録画面で線路を選択した時にそれに付随する駅情報を取得して反映させる

## 実装
方針通りで、特別な実装はない

## テスト
- 一度ユーザ情報を登録した端末で、再びアプリを開いた時にMainActivityにリダイレクトされていればOK
- 新規登録画面で駅情報と線路情報が取得できていればOK